### PR TITLE
ci: add CI workflow and dependency risk assessment

### DIFF
--- a/.github/dependency-risk-assessment.md
+++ b/.github/dependency-risk-assessment.md
@@ -1,0 +1,97 @@
+# 依赖升级风险评估
+
+> 评估日期：2026-02-17  
+> 评估人：ops-developer  
+> 项目：starter-nextjs-wagmi  
+> 总计过时依赖：33 个
+
+## 主分支状态
+
+| 检查项 | 状态 | 备注 |
+|--------|------|------|
+| TypeScript 类型检查 | ✅ 通过 | `tsc --noEmit -p tsconfig.app.json` |
+| ESLint | ✅ 通过 | `eslint .` |
+| 构建编译 (webpack) | ✅ 通过 | 61s 编译成功 |
+| SSG 静态生成 | ❌ 失败 | `localStorage.getItem` 在 SSR 中被调用（预存问题） |
+| 构建 (turbopack) | ❌ 失败 | webpack 配置未迁移到 turbopack（Next 16 默认） |
+
+## 已知安全漏洞
+
+- **next@16.0.8** — 已废弃，存在安全漏洞，需升级到补丁版本（见 nextjs.org/blog/security-update-2025-12-11）
+
+## peer 依赖冲突
+
+- `@heroui/theme@2.4.23` 需要 `tailwindcss>=4.0.0`，当前为 `3.4.16`
+- `@hairy/react-lib@1.46.0` 需要 `react@^18.2.0`，当前为 `19.2.1`
+- `use-sync-external-store@1.2.0`（wagmi 传递依赖）需要 `react@^16-18`，当前为 `19.2.1`
+
+---
+
+## 🔴 高风险（Major 升级，需大幅改动）
+
+| 包 | 当前 | 最新 | 风险说明 |
+|----|------|------|----------|
+| `next` | 16.0.8 | 16.1.6 | **安全补丁，必须升级**。16.0.8 已标记为废弃且有安全漏洞。升级到 16.1.x 应是 patch 级别变更，风险低。 |
+| `wagmi` | 2.16.9 | 3.4.4 | **Major 升级**。v3 改变了核心 API，需迁移连接器、hooks 等。涉及 `@rainbow-me/rainbowkit` 兼容性。**风险极高，建议单独分支处理。** |
+| `tailwindcss` | 3.4.16 | 4.1.18 | **Major 升级**。v4 配置系统全面重构（CSS-first config），需迁移 `tailwind.config.js`、PostCSS 配置、所有工具类。同时解决 `@heroui/theme` peer 依赖。**风险高。** |
+| `eslint` | 9.26.0 | 10.0.0 | **Major 升级**。可能影响所有 ESLint 插件兼容性。需与 `@antfu/eslint-config` 配合验证。 |
+| `@antfu/eslint-config` | 4.13.0 | 7.4.3 | **3 个 Major 跨版本**。配置 API 可能完全变化，需重写 `eslint.config.mjs`。 |
+| `@eslint-react/eslint-plugin` | 1.49.0 | 2.13.0 | **Major 升级**。规则名称/配置可能变更。 |
+| `eslint-plugin-react-hooks` | 5.2.0 | 7.0.1 | **2 个 Major 跨版本**。需验证与 eslint 10 兼容性。 |
+| `@hairy/lnv` | 6.3.0 | 9.1.0 | **3 个 Major 跨版本**。CLI 接口可能变化，影响所有 npm scripts（`lnv --`）。 |
+| `@types/node` | 22.15.16 | 25.2.3 | **3 个 Major 跨版本**。可能引入类型不兼容。 |
+| `unplugin-auto-import` | 19.2.0 | 21.0.0 | **2 个 Major 跨版本**。插件 API/配置可能变更。 |
+| `vitest` | 3.1.3 | 4.0.18 | **Major 升级**。测试 API 可能变化。 |
+| `tailwind-variants` | 0.3.0 | 3.2.2 | **3 个 Major 跨版本**（0.x → 3.x）。API 变化极大。 |
+
+## 🟡 中风险（Minor/Patch 但跨度较大）
+
+| 包 | 当前 | 最新 | 风险说明 |
+|----|------|------|----------|
+| `framer-motion` | 12.10.1 | 12.34.0 | Minor 更新跨度大（24 个 minor），但同一 major，风险可控。 |
+| `viem` | 2.41.2 | 2.46.1 | Minor 更新，Web3 核心库，需验证合约交互。 |
+| `eslint-plugin-format` | 1.0.1 | 1.4.0 | Minor 更新，风险低。 |
+| `eslint-plugin-react-refresh` | 0.4.20 | 0.5.0 | Minor 更新（0.x 阶段），可能有 breaking changes。 |
+| `etherlib-generator` | 0.2.1 | 0.3.3 | Minor 更新（0.x 阶段），影响代码生成。需验证 `postinstall` 脚本。 |
+| `iconify-svgo-loader` | 1.0.5 | 1.2.0 | Minor 更新，风险低。 |
+| `react` | 19.2.1 | 19.2.4 | Patch 更新，风险极低。 |
+| `react-dom` | 19.2.1 | 19.2.4 | Patch 更新，风险极低。 |
+
+## 🟢 低风险（Patch/Minor 小幅更新）
+
+| 包 | 当前 | 最新 | 风险说明 |
+|----|------|------|----------|
+| `@heroui/react` | 2.8.5 | 2.8.9 | Patch 更新。 |
+| `@heroui/theme` | 2.4.23 | 2.4.26 | Patch 更新。 |
+| `@tanstack/react-query` | 5.90.12 | 5.90.21 | Patch 更新。 |
+| `autoprefixer` | 10.4.19 | 10.4.24 | Patch 更新。 |
+| `@hairy/ether-lib` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
+| `@hairy/react-lib` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
+| `@hairy/utils` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
+| `@types/react` | 19.1.3 | 19.2.14 | Minor 更新。 |
+| `@types/react-dom` | 19.1.3 | 19.2.3 | Minor 更新。 |
+| `typescript` | 5.8.3 | 5.9.3 | Minor 更新，通常向后兼容。 |
+
+---
+
+## 建议升级策略
+
+### 第一阶段：安全补丁 + 低风险（立即执行）
+1. `next` 16.0.8 → 16.1.6（安全补丁，优先级最高）
+2. 所有 🟢 低风险 patch/minor 更新（批量升级）
+3. `react` / `react-dom` patch 更新
+
+### 第二阶段：中风险更新（需验证）
+1. `framer-motion`、`viem` minor 更新
+2. `eslint-plugin-*` 系列更新
+3. `etherlib-generator` 更新（需验证代码生成结果）
+
+### 第三阶段：Major 升级（需专项处理，各自独立分支）
+1. **ESLint 生态链**：`eslint` 10 + `@antfu/eslint-config` 7 + 相关插件（作为一组升级）
+2. **Tailwind CSS v4 迁移**：`tailwindcss` 4 + `tailwind-variants` 3 + `@heroui/theme` peer 修复
+3. **wagmi v3 迁移**：`wagmi` 3 + `viem` 最新 + `@rainbow-me/rainbowkit` 兼容性验证
+4. **工具链**：`@hairy/lnv` 9 + `unplugin-auto-import` 21 + `vitest` 4
+
+### 前置条件
+- ⚠️ 修复主分支 SSG 构建失败（`localStorage` SSR 问题）
+- ⚠️ 处理 Next.js 16 Turbopack 迁移（或明确使用 `--webpack` 模式）

--- a/.github/dependency-risk-assessment.md
+++ b/.github/dependency-risk-assessment.md
@@ -1,19 +1,19 @@
 # 依赖升级风险评估
 
-> 评估日期：2026-02-17  
-> 评估人：ops-developer  
-> 项目：starter-nextjs-wagmi  
+> 评估日期：2026-02-17
+> 评估人：ops-developer
+> 项目：starter-nextjs-wagmi
 > 总计过时依赖：33 个
 
 ## 主分支状态
 
-| 检查项 | 状态 | 备注 |
-|--------|------|------|
-| TypeScript 类型检查 | ✅ 通过 | `tsc --noEmit -p tsconfig.app.json` |
-| ESLint | ✅ 通过 | `eslint .` |
-| 构建编译 (webpack) | ✅ 通过 | 61s 编译成功 |
-| SSG 静态生成 | ❌ 失败 | `localStorage.getItem` 在 SSR 中被调用（预存问题） |
-| 构建 (turbopack) | ❌ 失败 | webpack 配置未迁移到 turbopack（Next 16 默认） |
+| 检查项              | 状态    | 备注                                               |
+| ------------------- | ------- | -------------------------------------------------- |
+| TypeScript 类型检查 | ✅ 通过 | `tsc --noEmit -p tsconfig.app.json`                |
+| ESLint              | ✅ 通过 | `eslint .`                                         |
+| 构建编译 (webpack)  | ✅ 通过 | 61s 编译成功                                       |
+| SSG 静态生成        | ❌ 失败 | `localStorage.getItem` 在 SSR 中被调用（预存问题） |
+| 构建 (turbopack)    | ❌ 失败 | webpack 配置未迁移到 turbopack（Next 16 默认）     |
 
 ## 已知安全漏洞
 
@@ -29,69 +29,73 @@
 
 ## 🔴 高风险（Major 升级，需大幅改动）
 
-| 包 | 当前 | 最新 | 风险说明 |
-|----|------|------|----------|
-| `next` | 16.0.8 | 16.1.6 | **安全补丁，必须升级**。16.0.8 已标记为废弃且有安全漏洞。升级到 16.1.x 应是 patch 级别变更，风险低。 |
-| `wagmi` | 2.16.9 | 3.4.4 | **Major 升级**。v3 改变了核心 API，需迁移连接器、hooks 等。涉及 `@rainbow-me/rainbowkit` 兼容性。**风险极高，建议单独分支处理。** |
-| `tailwindcss` | 3.4.16 | 4.1.18 | **Major 升级**。v4 配置系统全面重构（CSS-first config），需迁移 `tailwind.config.js`、PostCSS 配置、所有工具类。同时解决 `@heroui/theme` peer 依赖。**风险高。** |
-| `eslint` | 9.26.0 | 10.0.0 | **Major 升级**。可能影响所有 ESLint 插件兼容性。需与 `@antfu/eslint-config` 配合验证。 |
-| `@antfu/eslint-config` | 4.13.0 | 7.4.3 | **3 个 Major 跨版本**。配置 API 可能完全变化，需重写 `eslint.config.mjs`。 |
-| `@eslint-react/eslint-plugin` | 1.49.0 | 2.13.0 | **Major 升级**。规则名称/配置可能变更。 |
-| `eslint-plugin-react-hooks` | 5.2.0 | 7.0.1 | **2 个 Major 跨版本**。需验证与 eslint 10 兼容性。 |
-| `@hairy/lnv` | 6.3.0 | 9.1.0 | **3 个 Major 跨版本**。CLI 接口可能变化，影响所有 npm scripts（`lnv --`）。 |
-| `@types/node` | 22.15.16 | 25.2.3 | **3 个 Major 跨版本**。可能引入类型不兼容。 |
-| `unplugin-auto-import` | 19.2.0 | 21.0.0 | **2 个 Major 跨版本**。插件 API/配置可能变更。 |
-| `vitest` | 3.1.3 | 4.0.18 | **Major 升级**。测试 API 可能变化。 |
-| `tailwind-variants` | 0.3.0 | 3.2.2 | **3 个 Major 跨版本**（0.x → 3.x）。API 变化极大。 |
+| 包                            | 当前     | 最新   | 风险说明                                                                                                                                                         |
+| ----------------------------- | -------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next`                        | 16.0.8   | 16.1.6 | **安全补丁，必须升级**。16.0.8 已标记为废弃且有安全漏洞。升级到 16.1.x 应是 patch 级别变更，风险低。                                                             |
+| `wagmi`                       | 2.16.9   | 3.4.4  | **Major 升级**。v3 改变了核心 API，需迁移连接器、hooks 等。涉及 `@rainbow-me/rainbowkit` 兼容性。**风险极高，建议单独分支处理。**                                |
+| `tailwindcss`                 | 3.4.16   | 4.1.18 | **Major 升级**。v4 配置系统全面重构（CSS-first config），需迁移 `tailwind.config.js`、PostCSS 配置、所有工具类。同时解决 `@heroui/theme` peer 依赖。**风险高。** |
+| `eslint`                      | 9.26.0   | 10.0.0 | **Major 升级**。可能影响所有 ESLint 插件兼容性。需与 `@antfu/eslint-config` 配合验证。                                                                           |
+| `@antfu/eslint-config`        | 4.13.0   | 7.4.3  | **3 个 Major 跨版本**。配置 API 可能完全变化，需重写 `eslint.config.mjs`。                                                                                       |
+| `@eslint-react/eslint-plugin` | 1.49.0   | 2.13.0 | **Major 升级**。规则名称/配置可能变更。                                                                                                                          |
+| `eslint-plugin-react-hooks`   | 5.2.0    | 7.0.1  | **2 个 Major 跨版本**。需验证与 eslint 10 兼容性。                                                                                                               |
+| `@hairy/lnv`                  | 6.3.0    | 9.1.0  | **3 个 Major 跨版本**。CLI 接口可能变化，影响所有 npm scripts（`lnv --`）。                                                                                      |
+| `@types/node`                 | 22.15.16 | 25.2.3 | **3 个 Major 跨版本**。可能引入类型不兼容。                                                                                                                      |
+| `unplugin-auto-import`        | 19.2.0   | 21.0.0 | **2 个 Major 跨版本**。插件 API/配置可能变更。                                                                                                                   |
+| `vitest`                      | 3.1.3    | 4.0.18 | **Major 升级**。测试 API 可能变化。                                                                                                                              |
+| `tailwind-variants`           | 0.3.0    | 3.2.2  | **3 个 Major 跨版本**（0.x → 3.x）。API 变化极大。                                                                                                               |
 
 ## 🟡 中风险（Minor/Patch 但跨度较大）
 
-| 包 | 当前 | 最新 | 风险说明 |
-|----|------|------|----------|
-| `framer-motion` | 12.10.1 | 12.34.0 | Minor 更新跨度大（24 个 minor），但同一 major，风险可控。 |
-| `viem` | 2.41.2 | 2.46.1 | Minor 更新，Web3 核心库，需验证合约交互。 |
-| `eslint-plugin-format` | 1.0.1 | 1.4.0 | Minor 更新，风险低。 |
-| `eslint-plugin-react-refresh` | 0.4.20 | 0.5.0 | Minor 更新（0.x 阶段），可能有 breaking changes。 |
-| `etherlib-generator` | 0.2.1 | 0.3.3 | Minor 更新（0.x 阶段），影响代码生成。需验证 `postinstall` 脚本。 |
-| `iconify-svgo-loader` | 1.0.5 | 1.2.0 | Minor 更新，风险低。 |
-| `react` | 19.2.1 | 19.2.4 | Patch 更新，风险极低。 |
-| `react-dom` | 19.2.1 | 19.2.4 | Patch 更新，风险极低。 |
+| 包                            | 当前    | 最新    | 风险说明                                                          |
+| ----------------------------- | ------- | ------- | ----------------------------------------------------------------- |
+| `framer-motion`               | 12.10.1 | 12.34.0 | Minor 更新跨度大（24 个 minor），但同一 major，风险可控。         |
+| `viem`                        | 2.41.2  | 2.46.1  | Minor 更新，Web3 核心库，需验证合约交互。                         |
+| `eslint-plugin-format`        | 1.0.1   | 1.4.0   | Minor 更新，风险低。                                              |
+| `eslint-plugin-react-refresh` | 0.4.20  | 0.5.0   | Minor 更新（0.x 阶段），可能有 breaking changes。                 |
+| `etherlib-generator`          | 0.2.1   | 0.3.3   | Minor 更新（0.x 阶段），影响代码生成。需验证 `postinstall` 脚本。 |
+| `iconify-svgo-loader`         | 1.0.5   | 1.2.0   | Minor 更新，风险低。                                              |
+| `react`                       | 19.2.1  | 19.2.4  | Patch 更新，风险极低。                                            |
+| `react-dom`                   | 19.2.1  | 19.2.4  | Patch 更新，风险极低。                                            |
 
 ## 🟢 低风险（Patch/Minor 小幅更新）
 
-| 包 | 当前 | 最新 | 风险说明 |
-|----|------|------|----------|
-| `@heroui/react` | 2.8.5 | 2.8.9 | Patch 更新。 |
-| `@heroui/theme` | 2.4.23 | 2.4.26 | Patch 更新。 |
-| `@tanstack/react-query` | 5.90.12 | 5.90.21 | Patch 更新。 |
-| `autoprefixer` | 10.4.19 | 10.4.24 | Patch 更新。 |
-| `@hairy/ether-lib` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
-| `@hairy/react-lib` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
-| `@hairy/utils` | 1.46.0 | 1.47.0 | Minor 更新，自有库。 |
-| `@types/react` | 19.1.3 | 19.2.14 | Minor 更新。 |
-| `@types/react-dom` | 19.1.3 | 19.2.3 | Minor 更新。 |
-| `typescript` | 5.8.3 | 5.9.3 | Minor 更新，通常向后兼容。 |
+| 包                      | 当前    | 最新    | 风险说明                   |
+| ----------------------- | ------- | ------- | -------------------------- |
+| `@heroui/react`         | 2.8.5   | 2.8.9   | Patch 更新。               |
+| `@heroui/theme`         | 2.4.23  | 2.4.26  | Patch 更新。               |
+| `@tanstack/react-query` | 5.90.12 | 5.90.21 | Patch 更新。               |
+| `autoprefixer`          | 10.4.19 | 10.4.24 | Patch 更新。               |
+| `@hairy/ether-lib`      | 1.46.0  | 1.47.0  | Minor 更新，自有库。       |
+| `@hairy/react-lib`      | 1.46.0  | 1.47.0  | Minor 更新，自有库。       |
+| `@hairy/utils`          | 1.46.0  | 1.47.0  | Minor 更新，自有库。       |
+| `@types/react`          | 19.1.3  | 19.2.14 | Minor 更新。               |
+| `@types/react-dom`      | 19.1.3  | 19.2.3  | Minor 更新。               |
+| `typescript`            | 5.8.3   | 5.9.3   | Minor 更新，通常向后兼容。 |
 
 ---
 
 ## 建议升级策略
 
 ### 第一阶段：安全补丁 + 低风险（立即执行）
+
 1. `next` 16.0.8 → 16.1.6（安全补丁，优先级最高）
 2. 所有 🟢 低风险 patch/minor 更新（批量升级）
 3. `react` / `react-dom` patch 更新
 
 ### 第二阶段：中风险更新（需验证）
+
 1. `framer-motion`、`viem` minor 更新
 2. `eslint-plugin-*` 系列更新
 3. `etherlib-generator` 更新（需验证代码生成结果）
 
 ### 第三阶段：Major 升级（需专项处理，各自独立分支）
+
 1. **ESLint 生态链**：`eslint` 10 + `@antfu/eslint-config` 7 + 相关插件（作为一组升级）
 2. **Tailwind CSS v4 迁移**：`tailwindcss` 4 + `tailwind-variants` 3 + `@heroui/theme` peer 修复
 3. **wagmi v3 迁移**：`wagmi` 3 + `viem` 最新 + `@rainbow-me/rainbowkit` 兼容性验证
 4. **工具链**：`@hairy/lnv` 9 + `unplugin-auto-import` 21 + `vitest` 4
 
 ### 前置条件
+
 - ⚠️ 修复主分支 SSG 构建失败（`localStorage` SSR 问题）
 - ⚠️ 处理 Next.js 16 Turbopack 迁移（或明确使用 `--webpack` 模式）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec tsc --noEmit -p tsconfig.app.json
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    # SSG 阶段存在 localStorage SSR 调用问题（预存 bug），编译本身通过
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec next build --webpack

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^12.10.1
         version: 12.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next:
-        specifier: 15.2.4
-        version: 15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: 16.0.8
+        version: 16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -234,11 +234,11 @@ packages:
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
 
-  '@emnapi/runtime@1.3.1':
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
-
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
@@ -1349,107 +1349,139 @@ packages:
     resolution: {integrity: sha512-VJGcd2Z51RdhAn+sSW/2wOplOUGgUienHp57TuGpbjZI/YD4qBDRFOe6uvqUrgsOjRLf+YEIkILck0LMH+mB8A==}
     engines: {node: '>= 18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+  '@img/colour@1.0.0':
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -1589,53 +1621,53 @@ packages:
   '@napi-rs/wasm-runtime@0.2.9':
     resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
 
-  '@next/env@15.2.4':
-    resolution: {integrity: sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==}
+  '@next/env@16.0.8':
+    resolution: {integrity: sha512-xP4WrQZuj9MdmLJy3eWFHepo+R3vznsMSS8Dy3wdA7FKpjCiesQ6DxZvdGziQisj0tEtCgBKJzjcAc4yZOgLEQ==}
 
-  '@next/swc-darwin-arm64@15.2.4':
-    resolution: {integrity: sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==}
+  '@next/swc-darwin-arm64@16.0.8':
+    resolution: {integrity: sha512-yjVMvTQN21ZHOclQnhSFbjBTEizle+1uo4NV6L4rtS9WO3nfjaeJYw+H91G+nEf3Ef43TaEZvY5mPWfB/De7tA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.2.4':
-    resolution: {integrity: sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==}
+  '@next/swc-darwin-x64@16.0.8':
+    resolution: {integrity: sha512-+zu2N3QQ0ZOb6RyqQKfcu/pn0UPGmg+mUDqpAAEviAcEVEYgDckemOpiMRsBP3IsEKpcoKuNzekDcPczEeEIzA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.2.4':
-    resolution: {integrity: sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==}
+  '@next/swc-linux-arm64-gnu@16.0.8':
+    resolution: {integrity: sha512-LConttk+BeD0e6RG0jGEP9GfvdaBVMYsLJ5aDDweKiJVVCu6sGvo+Ohz9nQhvj7EQDVVRJMCGhl19DmJwGr6bQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.2.4':
-    resolution: {integrity: sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==}
+  '@next/swc-linux-arm64-musl@16.0.8':
+    resolution: {integrity: sha512-JaXFAlqn8fJV+GhhA9lpg6da/NCN/v9ub98n3HoayoUSPOVdoxEEt86iT58jXqQCs/R3dv5ZnxGkW8aF4obMrQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.2.4':
-    resolution: {integrity: sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==}
+  '@next/swc-linux-x64-gnu@16.0.8':
+    resolution: {integrity: sha512-O7M9it6HyNhsJp3HNAsJoHk5BUsfj7hRshfptpGcVsPZ1u0KQ/oVy8oxF7tlwxA5tR43VUP0yRmAGm1us514ng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.2.4':
-    resolution: {integrity: sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==}
+  '@next/swc-linux-x64-musl@16.0.8':
+    resolution: {integrity: sha512-8+KClEC/GLI2dLYcrWwHu5JyC5cZYCFnccVIvmxpo6K+XQt4qzqM5L4coofNDZYkct/VCCyJWGbZZDsg6w6LFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.2.4':
-    resolution: {integrity: sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==}
+  '@next/swc-win32-arm64-msvc@16.0.8':
+    resolution: {integrity: sha512-rpQ/PgTEgH68SiXmhu/cJ2hk9aZ6YgFvspzQWe2I9HufY6g7V02DXRr/xrVqOaKm2lenBFPNQ+KAaeveywqV+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.2.4':
-    resolution: {integrity: sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==}
+  '@next/swc-win32-x64-msvc@16.0.8':
+    resolution: {integrity: sha512-jWpWjWcMQu2iZz4pEK2IktcfR+OA9+cCG8zenyLpcW8rN4rzjfOzH4yj/b1FiEAZHKS+5Vq8+bZyHi+2yqHbFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2617,9 +2649,6 @@ packages:
     peerDependencies:
       eslint: '>=9.0.0'
 
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -3307,10 +3336,6 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -3676,6 +3701,10 @@ packages:
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
@@ -5055,13 +5084,14 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  next@15.2.4:
-    resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+  next@16.0.8:
+    resolution: {integrity: sha512-LmcZzG04JuzNXi48s5P+TnJBsTGPJunViNKV/iE4uM6kstjTQsQhvsAv+xF6MJxU2Pr26tl15eVbp0jQnsv6/g==}
+    engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
@@ -5685,6 +5715,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
@@ -5711,8 +5746,8 @@ packages:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
     hasBin: true
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -5822,10 +5857,6 @@ packages:
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
 
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -6834,12 +6865,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.3.1':
+  '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.3':
+  '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8361,79 +8392,101 @@ snapshots:
       '@ignored/edr-linux-x64-musl': 0.10.0-alpha.3
       '@ignored/edr-win32-x64-msvc': 0.10.0-alpha.3
 
-  '@img/sharp-darwin-arm64@0.33.5':
+  '@img/colour@1.0.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.33.5':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.33.5':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.33.5':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.33.5':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.3.1
+      '@emnapi/runtime': 1.8.1
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.33.5':
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@internationalized/date@3.10.0':
@@ -8698,30 +8751,30 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next/env@15.2.4': {}
+  '@next/env@16.0.8': {}
 
-  '@next/swc-darwin-arm64@15.2.4':
+  '@next/swc-darwin-arm64@16.0.8':
     optional: true
 
-  '@next/swc-darwin-x64@15.2.4':
+  '@next/swc-darwin-x64@16.0.8':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.2.4':
+  '@next/swc-linux-arm64-gnu@16.0.8':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.2.4':
+  '@next/swc-linux-arm64-musl@16.0.8':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.2.4':
+  '@next/swc-linux-x64-gnu@16.0.8':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.2.4':
+  '@next/swc-linux-x64-musl@16.0.8':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.2.4':
+  '@next/swc-win32-arm64-msvc@16.0.8':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.2.4':
+  '@next/swc-win32-x64-msvc@16.0.8':
     optional: true
 
   '@noble/ciphers@1.2.1': {}
@@ -10339,8 +10392,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -11542,10 +11593,6 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -11862,6 +11909,9 @@ snapshots:
   detect-browser@5.3.0: {}
 
   detect-libc@2.0.3:
+    optional: true
+
+  detect-libc@2.1.2:
     optional: true
 
   detect-node-es@1.1.0: {}
@@ -13656,28 +13706,26 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@16.0.8(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
-      '@next/env': 15.2.4
-      '@swc/counter': 0.1.3
+      '@next/env': 16.0.8
       '@swc/helpers': 0.5.15
-      busboy: 1.6.0
       caniuse-lite: 1.0.30001701
       postcss: 8.4.31
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       styled-jsx: 5.1.6(react@19.2.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.4
-      '@next/swc-darwin-x64': 15.2.4
-      '@next/swc-linux-arm64-gnu': 15.2.4
-      '@next/swc-linux-arm64-musl': 15.2.4
-      '@next/swc-linux-x64-gnu': 15.2.4
-      '@next/swc-linux-x64-musl': 15.2.4
-      '@next/swc-win32-arm64-msvc': 15.2.4
-      '@next/swc-win32-x64-msvc': 15.2.4
+      '@next/swc-darwin-arm64': 16.0.8
+      '@next/swc-darwin-x64': 16.0.8
+      '@next/swc-linux-arm64-gnu': 16.0.8
+      '@next/swc-linux-arm64-musl': 16.0.8
+      '@next/swc-linux-x64-gnu': 16.0.8
+      '@next/swc-linux-x64-musl': 16.0.8
+      '@next/swc-win32-arm64-msvc': 16.0.8
+      '@next/swc-win32-x64-msvc': 16.0.8
       '@opentelemetry/api': 1.9.0
-      sharp: 0.33.5
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -14291,6 +14339,9 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.7.4:
+    optional: true
+
   send@1.2.0:
     dependencies:
       debug: 4.4.0
@@ -14336,31 +14387,36 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
-  sharp@0.33.5:
+  sharp@0.34.5:
     dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.3
-      semver: 7.7.1
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:
@@ -14476,8 +14532,6 @@ snapshots:
   std-env@3.9.0: {}
 
   stream-shift@1.0.3: {}
-
-  streamsearch@1.1.0: {}
 
   strict-uri-encode@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with 3 parallel jobs: **Lint**, **Type Check**, **Build**
- Uses pnpm action-setup v4 with Node 22 and frozen lockfile
- Build job uses --webpack flag (turbopack migration pending) and continue-on-error for known SSG localStorage issue
- Add comprehensive dependency risk assessment for 33 outdated packages, categorized into 3 upgrade phases

## Dependency Risk Assessment Highlights
- **Phase 1 (immediate)**: next security patch 16.0.8 -> 16.1.6 + all low-risk patches
- **Phase 2 (validation needed)**: framer-motion, viem, eslint plugins minor updates
- **Phase 3 (dedicated branches)**: wagmi v3, tailwindcss v4, eslint 10 major upgrades

## Test plan
- [ ] Verify CI workflow triggers on push to main and PRs
- [ ] Confirm lint job passes with current codebase
- [ ] Confirm typecheck job passes with tsconfig.app.json
- [ ] Verify build job completes (expect continue-on-error for SSG issue)

Made with [Cursor](https://cursor.com)